### PR TITLE
Minimize mention of aliasing

### DIFF
--- a/_posts/2010-01-05-using-dev-tools.md
+++ b/_posts/2010-01-05-using-dev-tools.md
@@ -37,8 +37,8 @@ The elements panel shows the HTML source of a page in a neat hierarchy. This hel
 As you browse during testing, look for requests to `trk.kissmetrics.com`; these tracking URLs will be structured according to our [API specifications][specs].
 
 * `trk.kissmetrics.com/e` : for `record`ing an event
-* `trk.kissmetrics.com/a` : for `alias`
 * `trk.kissmetrics.com/s` : for `set`ting properties without an event
+* `trk.kissmetrics.com/a` : for `alias`
 
 [![Network Panel][network-ss]][network-ss]
 

--- a/_posts/2012-10-19-live.md
+++ b/_posts/2012-10-19-live.md
@@ -5,7 +5,7 @@ categories: tools
 author: Eric Fung
 summary: Live lets you look at the results of calling 'record', 'set', and 'alias' in real-time.
 ---
-Our [Live feature][live] lets you look at your site's activity in real-time. Specifically, you'll see events being recorded, properties being set, and identities being aliased together. (Calling `identify` does not necessarily show up in Live unless it causes our JavaScript to also alias an anonymous ID to a named ID.)
+Our [Live feature][live] lets you look at your site's activity in real-time. Specifically, you'll see events being recorded, properties being set, and identities being aliased together. (Calling `identify` shows up in Live when it causes our JavaScript to also alias an anonymous ID to a named ID.)
 
 Whether you are testing new KISSmetrics events or watching how an individual user navigates your site, Live is your access to real-time activity. Live now lets you filter your activity so you can narrow down the feed to specific people or events, while still allowing you to see everything else that happened in the meantime.
 

--- a/_posts/2012-10-19-multiple-people-same-browser.md
+++ b/_posts/2012-10-19-multiple-people-same-browser.md
@@ -5,7 +5,7 @@ categories: advanced
 author: John Butler
 summary: What happens if multiple people use the same computer? How to reset the KISSmetrics identity tracking when a user logs out.
 ---
-What happens if two people use the same computer and you call `identify` multiple times? KISSmetrics **will not** alias the two named identities together (it will recognize them as separate people). However, it should be noted that any activity before you call `identify` for the second user will be attributed to the first user. Let's see how this works:
+What happens if two people use the same computer and you call `identify` multiple times? KISSmetrics will recognize the different identities as separate people. However, it should be noted that any activity before you call `identify` for the second user will be attributed to the first user. Let's see how this works:
 
 1. Bob comes to your site and is assigned the anonymous identity `qFq2LweZugFNE4o49hLhmRPBW34`
 2. Bob then logs in and you call `identify` telling us that the identity is now `bob@site.com`. The activity from before Bob logs in (when we knew him as `qFq2LweZugFNE4o49hLhmRPBW34`) is automatically tied to `bob@site.com`.

--- a/_posts/2012-11-06-tracking-multiple-domains.md
+++ b/_posts/2012-11-06-tracking-multiple-domains.md
@@ -88,7 +88,7 @@ _kmq.push(function() {  // we wrap the code in a function to ensure our library 
 </script>
 {% endhighlight %}
 
-Down the line, if the customer ever goes from being anonymous to providing some identifying info, you'll have to [alias][alias] the anonymized and known id's together, rather than rely on `identify` to do the job. (The URL API treats the transferred ID as a "known" ID.)
+Down the line, if the customer ever goes from being anonymous to providing some identifying info, you'll have to alias the anonymized and known id's together, rather than rely on `identify` to do the job. (The URL API treats the transferred ID as a "known" ID.)
 
 {% highlight html %}
 <script type="text/javascript">
@@ -118,6 +118,5 @@ For reference: [Looking Up Your Current KM ID][km-id]
 
 [url]: /apis/url
 [km-id]: /apis/javascript/javascript-specific#get-your-current-kissmetrics-id
-[alias]: /apis/common-methods#alias
 [js-settings]: https://s3.amazonaws.com/kissmetrics-support-files/assets/apis/javascript/tracking-multiple-domains/include-host.png
 [auto-track]: /apis/javascript/javascript-settings

--- a/_posts/2013-02-04-csv-import.md
+++ b/_posts/2013-02-04-csv-import.md
@@ -22,11 +22,11 @@ Then include at least one of these three columns, depending on what type of data
 
 * **"Event"** (*optional*): You can add an event name, such as "Signed Up". It does not matter if you currently have data for this event, or if this is a completely new event. **If you are importing events, each row needs an event. To set only properties, set those aside in a separate CSV file.**
 * **"Prop:"Property Name** (*optional*): You can add property columns by giving them the title "Prop:" and then adding the property name. For example, "Prop:Age" or "Prop:Billing Amount". You can include up to 10 property columns.
-* **"Alias"** (*optional*): You can add additional aliases to the KM identity.
+* **"Alias"** (*optional*): in the rare case you are uploading [aliases][alias], you can add additional aliases to the KM identity.
 
 ### Examples
 
-#### Importing only events (`record` command):
+#### Importing only events (`record` command)
 
 Identity | Timestamp  | Event
 -------- | ---------- | ----------
@@ -36,7 +36,7 @@ Identity | Timestamp  | Event
 6        | 1325974373 | Joined Newsletter
 10       | 1325629592 | Subscribed
 
-#### Importing events with optional properties (`record` command with properties):
+#### Importing events with optional properties (`record` command with properties)
 
 Identity | Timestamp  | Event             | Prop:Age  | Prop:Gender | Prop:Favorite Food
 -------- | ---------- | ----------------- | --------- | ----------- | ------------------
@@ -46,7 +46,7 @@ Identity | Timestamp  | Event             | Prop:Age  | Prop:Gender | Prop:Favor
 6        | 1325974373 | Joined Newsletter |           |             | Tapas
 10       | 1325629592 | Subscribed        | 23        | Male        | Apple Pie
 
-#### Importing only properties (`set` command):
+#### Importing only properties (`set` command)
 
 Identity | Timestamp  | Prop:Email Address
 -------- | ---------- | ------------------
@@ -56,7 +56,9 @@ Identity | Timestamp  | Prop:Email Address
 6        | 1325974373 | joe@bob.com
 10       | 1325629592 | phil@bob.com
 
-#### Importing optional aliases (`alias` command):
+#### Importing optional aliases (`alias` command)
+
+It's [uncommon to upload aliases][alias], but this is the format if you absolutely needed to:
 
 Identity     | Alias          | Timestamp 
 ------------ | -------------- | ----------
@@ -74,3 +76,4 @@ mrtaft2      | ht@example.com | 1230768000
 [pep]: /getting-started/people-events-properties
 [common-methods]: /apis/common-methods
 [sample-csv]: https://s3.amazonaws.com/kissmetrics-support-files/assets/integrations/csv-import/csv-import-sample.csv
+[alias]: /apis/specifications#when-to-alias

--- a/_posts/2013-04-16-objective-c.md
+++ b/_posts/2013-04-16-objective-c.md
@@ -5,7 +5,7 @@ categories: apis
 author: Will Rust
 summary: Information about our basic Objective-C/Cocoa library, for iOS and OS X apps.
 ---
-Bring KISSmetrics to your iOS and OS X apps with our Objective-C library. It allows you to record events, set properties and alias users. 
+Bring KISSmetrics to your iOS and OS X apps with our Objective-C library. It allows you to record events and set properties.
 
 ## Setup
 

--- a/_posts/2013-04-17-python.md
+++ b/_posts/2013-04-17-python.md
@@ -7,10 +7,10 @@ author: Eric Fung
 summary: Information about our Python library.
 permalink: /apis/python/index.html
 ---
-Our Python Library has the basic functionality laid out in our [API specifications][specs]. It allows you to record events, set properties and alias users. However, you might miss these features:
+Our Python Library has the basic functionality laid out in our [API specifications][specs]. It allows you to record events and set properties. However, you might miss these features:
 
 * No built-in mechanisms for generating and saving identities for your users
-* No built-in mechanisms for automatically tying together *anonymous* and *named* identities. This can still be done manually with the `alias` API call - please refer to [our guide for managing identities][identity].
+* No built-in mechanisms for automatically tying together *anonymous* and *named* identities.
 * No built-in mechanisms for running A/B tests
 * No automatic triggering of Events (such as detecting Search Engine traffic)
 * Does not support [scheduling sending data via cron][cron]
@@ -48,7 +48,6 @@ km.record('Viewed Homepage');
 km.record('Signed Up', {'Plan' : 'Pro', 'Amount' : 99.95});
 km.record('Signed Up', {'_d' : 1, '_t' : 1234567890});
 km.set({'gender' : 'male'});
-km.alias('bob', 'bob@bob.com');
 {% endhighlight %}
 
 ## Troubleshooting

--- a/_posts/2013-04-18-php.md
+++ b/_posts/2013-04-18-php.md
@@ -7,10 +7,10 @@ author: Eric Fung
 summary: Information about our PHP library.
 permalink: /apis/php/index.html
 ---
-Our PHP Library has the basic functionality laid out in our [API specifications][specs]. It allows you to record events, set properties and alias users. However, you might miss these features from our JavaScript library:
+Our PHP Library has the basic functionality laid out in our [API specifications][specs]. It allows you to record events and set properties. However, you might miss these features from our JavaScript library:
 
 * No built-in mechanisms for generating and saving identities for your users
-* No built-in mechanisms for automatically tying together *anonymous* and *named* identities. This can still be done manually with the `alias` API call - please refer to [our guide for managing identities][identity].
+* No built-in mechanisms for automatically tying together *anonymous* and *named* identities.
 * No built-in mechanisms for running A/B tests
 * No automatic triggering of Events (such as detecting Search Engine traffic)
 
@@ -59,7 +59,6 @@ Example:
   KM::record('Signed Up', array('Plan' => 'Pro', 'Amount' => 99.95));
   KM::record('Signed Up', array('_d' => 1, '_t' => 1234567890));
   KM::set(array('gender'=>'male'));
-  KM::alias('bob', 'bob@bob.com');
 ?>
 {% endhighlight %}
 

--- a/_posts/2013-04-18-ruby.md
+++ b/_posts/2013-04-18-ruby.md
@@ -13,10 +13,10 @@ permalink: /apis/ruby/index.html
 
 ## Ruby library
 
-Our Ruby Library has the basic functionality laid out in our [API specifications][specs]. It allows you to record events, set properties and alias users. However, you might miss these features from our JavaScript library:
+Our Ruby Library has the basic functionality laid out in our [API specifications][specs]. It allows you to record events and set properties. However, you might miss these features from our JavaScript library:
 
 * No built-in mechanisms for generating and saving identities for your users
-* No built-in mechanisms for automatically tying together *anonymous* and *named* identities. This can still be done manually with the `alias` API call - please refer to [our guide for managing identities][identity].
+* No built-in mechanisms for automatically tying together *anonymous* and *named* identities.
 * No built-in mechanisms for running A/B tests
 * No automatic triggering of Events (such as detecting Search Engine traffic)
 
@@ -60,7 +60,6 @@ KM.record('Viewed Homepage')
 KM.record('Signed Up', {'Plan' => 'Pro', 'Amount' => 99.95})
 KM.record('Signed Up', {'_d' => 1, '_t' => 1234567890})
 KM.set({:gender=>'male', 'Plan Name' => 'Pro'})
-KM.alias('bob', 'bob@bob.com')
 {% endhighlight %}
 
 ## Troubleshooting

--- a/_posts/2013-04-19-javascript-specific.md
+++ b/_posts/2013-04-19-javascript-specific.md
@@ -14,8 +14,7 @@ permalink: /apis/javascript/javascript-specific/index.html
 `_kmq.push(['record', 'EVENT_NAME']);` | Records an event.
 `_kmq.push(['record', 'EVENT_NAME', {'PROPERTY_NAME':'VALUE'}]);` | Records an event with additional properties.
 `_kmq.push(['set', {'PROPERTY_NAME':'VALUE'}]);` | Sets properties to the current user.
-`_kmq.push(['identify', 'IDENTITY']);` | Identifies the current person with a **unique** ID, and attributes future events from this browser to this provided ID. If the current person is 'anonymous', it also connects their 'anonymous' ID to the provided ID so we recognize both as being the same person (see `alias` below). Calling `identify` does *not* count as an "event".
-`_kmq.push(['alias', 'ID1', 'ID2']);` | Connects two identities so we recognize both as being the same person. We need to see events done by both ID's; if you want to save additional identifying information like "First Name" or "Last Name", consider using `set` instead. Calling `alias` does *not* count as an "event".
+`_kmq.push(['identify', 'IDENTITY']);` | Identifies the current person with a **unique** ID, and attributes future events from this browser to this provided ID. If the current person is 'anonymous', it also connects their 'anonymous' ID to the provided ID so we recognize both as being the same person (`alias`ing). Calling `identify` does *not* count as an "event".
 
 JavaScript-Specific Methods | Description
 --------------------------- | -----------

--- a/_posts/2013-04-20-javascript.md
+++ b/_posts/2013-04-20-javascript.md
@@ -107,9 +107,6 @@ _kmq.push(['record', 'Signed Up', {'Plan':'Pro', 'Amount':99.95}]);
 // Sets the "Gender" property to "Male" for the current person
 _kmq.push(['set', {'gender':'male'}]);  
 
-// Connects "bob" and "bob@bob.com" to represent the same person
-_kmq.push(['alias', 'bob', 'bob@bob.com']);
-
 /* Records an event "Signed Up" in the past.
  * This demonstrates how to pass the '_t' and '_d' from our
  * specifications as regular KISSmetrics properties.

--- a/_posts/2013-04-22-common-methods.md
+++ b/_posts/2013-04-22-common-methods.md
@@ -14,7 +14,6 @@ Command    | Description
 `record`   | Tracks that the current person performed an action.
 `set`      | Saves additional properties about the person, which you use to segment groups of people into cohorts.
 `identify` | Sets the identity of the current person, so we know who to attribute future events to.
-`alias`    | Connects two identities together to represent the same person.
 
 <a name="record"></a>
 ## `record`
@@ -51,31 +50,7 @@ Here's an example of an `identify` call in a Ruby app that obtains the current v
 
 For more information on how to handle identities, please refer to this [Identity Management guide][id].
 
-<a name="alias"></a>
-## `alias`
-
-Alias is used to associate one identity with another, so that both identities represent the same person. In other words, if ID-A has done events and ID-B has also done events, after aliasing ID-A and ID-B together, we'll show that both of these ID's had been the same person doing all of the events all along.
-
-[![][alias-regular]][alias-regular]
-
-**Calling `alias` is not reversible, and should be used situationally. If you want to add additional information about a person, setting an additional property usually is enough (for example, adding an email address to someone currently identified by their Facebook ID).**
-
-[![][alias-vs-set]][alias-vs-set]
-
-Our JavaScript Library easily handles the common scenarios of attributing someone's activity while they are anonymous to their post-signup activity, without you having to make the `alias` API call. Please refer to [Identities with the JavaScript Library][js-ids] for more details. However, there are some scenarios where it may be appropriate to call `alias` directly:
-
-* When you implement KISSmetrics using more than one source of data: combining data from an external KM [integration][integration], server-side libraries, and/or our JavaScript library.
-* When you are identifying people by their email address, and they update their email address within your app.
-
-Notes:
-
-* It’s fine to call `alias` more than once with the same pair of identities.
-* It’s fine if a person has more than one alias.
-* The order you pass the two arguments does not matter.
-* After calling `alias`, the new alias does not appear in a person's list of Customer IDs unless you have triggered an event or set properties to the new alias.
-
-[![][alias-zero]][alias-zero]
-
+<a name="examples"></a>
 ## Examples
 Below are some examples for the standard API. Please see APIs for supported languages.
 
@@ -100,8 +75,6 @@ _kmq.push(['record', 'Signed Up', {'_d':1, '_t':1234567890}])
 // Sets the "Gender" property to "Male" for the current person
 _kmq.push(['set', {'gender':'male'}]);  
 
-// Connects "bob" and "bob@bob.com" to represent the same person
-_kmq.push(['alias', 'bob', 'bob@bob.com']);
 {% endhighlight %}
 
 ### PHP
@@ -112,7 +85,6 @@ _kmq.push(['alias', 'bob', 'bob@bob.com']);
  KM::record('Signed Up', array('Plan' => 'Pro', 'Amount' => 99.95));
  KM::record('Signed Up', array('_d' => 1, '_t' => 1234567890));
  KM::set(array('gender'=>'male'));
- KM::alias('bob', 'bob@bob.com');
 ?>
 {% endhighlight %}
 
@@ -123,7 +95,6 @@ KM.record('Viewed Homepage')
 KM.record('Signed Up', {'Plan' => 'Pro', 'Amount' => 99.95})
 KM.record('Signed Up', {'_d' => 1, '_t' => 1234567890})
 KM.set({:gender=>'male', 'Plan Name' => 'Pro'})
-KM.alias('bob', 'bob@bob.com')
 {% endhighlight %}
 
 ### Python
@@ -133,14 +104,7 @@ KM.record('Viewed Homepage');
 KM.record('Signed Up', {'Plan' : 'Pro', 'Amount' : 99.95});
 KM.record('Signed Up', {'_d' : 1, '_t' : 1234567890});
 KM.set({'gender' : 'male'});
-KM.alias('bob', 'bob@bob.com');
 {% endhighlight %}
 
 [js]: /apis/javascript/javascript-specific
 [id]: /getting-started/understanding-identities
-[tips]: /apis/api-tips
-[js-ids]: https://s3.amazonaws.com/kissmetrics-support-files/assets/getting-started/understanding-identities/js-ids.pdf
-[integration]: /integrations
-[alias-regular]: https://s3.amazonaws.com/kissmetrics-support-files/assets/troubleshooting/troubleshooting-identities/alias-regular.png
-[alias-vs-set]: https://s3.amazonaws.com/kissmetrics-support-files/assets/troubleshooting/troubleshooting-identities/alias-vs-set.png
-[alias-zero]: https://s3.amazonaws.com/kissmetrics-support-files/assets/troubleshooting/troubleshooting-identities/alias-zero.png

--- a/_posts/2013-04-23-specifications.md
+++ b/_posts/2013-04-23-specifications.md
@@ -90,23 +90,26 @@ Parameters | Format             | Necessary? | Description
 
 **Example**
 
-    http://trk.kissmetrics.com/a?_k=api-key&_p=bob&_n=bob%40bob.com
+    http://trk.kissmetrics.com/a?_k=api-key&_p=User+12345&_n=bob%40bob.com
 
-This tells us to represent events done by `User 12345` and `bob@bob.com` as having been done by the same person. If you log events or properties to either ID, they all refer back to the same one person. (`bob@bob.com` is passed as `bob%40bob.com` because the `@` needs to be [URL-encoded][encoding].)
+This tells us that events done by `User 12345` and events done by `bob@bob.com` were done by the same person. If you log events or properties to either ID, they all refer back to the same one person.
 
 **Calling `alias` is not reversible, and should be used with some caution.**
 
-There are some scenarios where it may be appropriate to call `alias` directly:
+<a name="when-to-alias"></a>
+### When to Alias
 
-* When you implement KISSmetrics using more than one source of data: combining data from an external KM [integration][integration], server-side libraries, and/or our JavaScript library.
-* When you are identifying people by their email address, and they update their email address within your app.
-* When you are combining someone's anonymous activity and referral data to the data with their usage data after they are a returning customer.
+There are only a handful of scenarios where it is appropriate to directly call `alias`:
+
+* You implement KISSmetrics using more than one source of data: combining data from an external KM [integration][integration], server-side libraries, and/or our JavaScript library.
+* You are identifying people by their email address, and they update their email address within your app.
+* You change your tracking schema to identify people...say, from email address to username.
 
 Notes:
 
-* After calling `alias`, the new alias does not appear in a person's list of Customer IDs unless you have triggered an event or set properties to the new alias.
+* After calling `alias`, the new alias does not appear in a person's list of Customer IDs unless the new alias has triggered an event or has properties set properties.
 * It’s fine to call `alias` more than once with the same pair of identities.
-* It’s fine if a person has more than one alias.
+* It’s natural if a person has more than one alias.
 * The order you pass the two arguments does not matter.
 
 <a name="url-builder"></a>

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -150,7 +150,7 @@ img {
 }
 .col p {
   color: #656565;
-  font-size: 16px;
+  font-size: 14px;
   line-height: 26px;
   margin-bottom: 20px;
 }
@@ -165,7 +165,7 @@ img {
 }
 .col li {
   color: #656565;
-  font-size: 16px;
+  font-size: 14px;
   
   margin-bottom: 4px;
   line-height: 25px;

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,744 +2,744 @@
 <urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/overview.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/people-events-properties.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/ways-to-send-us-data.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/testing-km/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/testing-km/using-dev-tools.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:24:56-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/understanding-identities.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/faq.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/security.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/account-billing.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/advanced-properties.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/browser-detection.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/call-tracking-metrics.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/campaign-tracking.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/chargify.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/cohort-report/cohort-report-options.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/create-site.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/daily-metrics-email.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/data-discrepancies/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/data/data-export-setup.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/deleting-data.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/detecting-duplicates.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/dynamic-elements.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/ecommerce-essentials.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/index.html</loc>
-        <lastmod>2013-08-14T21:56:28-04:00</lastmod>
+        <lastmod>2013-08-21T13:57:07-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/event-library-tutorial/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tutorial/event-library-tutorial/events-and-properties-tutorial.html
         </loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/events-clicks.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tutorial/event-library-tutorial/events-clicks-tutorial.html
         </loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/events-form.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tutorial/event-library-tutorial/events-form-tutorial.html
         </loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/events-url/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tutorial/event-library-tutorial/events-url-tutorial.html
         </loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/feature-metrics.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/feature-reports.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/feature-revenue-report.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/form-abandonment.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/funnels/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/funnels-vs-metrics.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/ruby/heroku.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/hosting-js-yourself.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/how-is-kissmetrics-different.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/how-to-build-reports.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/html-files.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/importing-data.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/installation/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/integration.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/internet-explorer.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/introduction.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/ip-filtering.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/javascript-identities.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/javascript-settings.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/data-discrepancies/km-ga.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/live.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:41:33-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/local-development.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/magento-km.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/mailchimp.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/metrics/metric-calculations.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/metrics/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/metrics-intro.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/mobile-sites-apps.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/multiple-people-same-browser.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:40:46-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/csv-import/one-time-upload.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/optimizely.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/payplans.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/person-details.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/person-or-account.html</loc>
-        <lastmod>2013-08-07T20:44:48-04:00</lastmod>
+        <lastmod>2013-08-06T15:36:14-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/php/php-specific.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/power-report/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/apis/javascript/javascript-specific/protected-form-fields.html
         </loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/python/python-gae.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/qualaroo.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/recurly.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/csv-import/recurring-import.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/power-report/relative-to.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/reports-exportable.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/revenue-report.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/ruby/ruby-on-rails.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/saas-essentials.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tools/funnels/segment-funnels-two-properties.html
         </loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/self-referrer.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/server-side.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/site-settings.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/social-events.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/time-on-site.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/time-zones.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/too-many-event-names.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/top-vs-bottom.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/tracking-email.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/tracking-offline-events.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/tracking-refunds.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/tracking-video.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/traffic-sources.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/troubleshooting-properties.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/user-privacy.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/using-paypal.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/utm-variables.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/virality.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/vwo.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/webinar-getting-started.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/using-km-js/weighted-variants.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/what-can-km-do-for-me.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/what-should-i-measure.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/what-youll-learn.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/using-km-js/whole-page.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/events-url/wildcards.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/woocommerce.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/wordpress.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/installation/wordpress-tutorial.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/wufoo-forms.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/cohort-report/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/events-intro.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/five-awesome-things.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/google-tag-manager.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/km-live.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/people-search.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/ultracart.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/tracking-multiple-domains.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:22:38-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/mysql/arg-out-of-range.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/delete-site.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/main-saas-funnel.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/paid-ads.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/roi-email-marketing.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/roi-of-seo.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/roi-social-media.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/social-media.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/team-permissions.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/salesforce.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/finding-power-users.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/marketing-power-report.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/change-password.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/compare-features-power-report.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/roi-campaigns.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/stop-events.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/csv-import/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:58:09-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/mysql/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/using-km-js/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/styleguide.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/troubleshooting-identities.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/update-frequency.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/what-does-none-mean.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/troubleshooting/common-cohort-report-questions.html
         </loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/saas-revenue-essentials.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/help-scout.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/power-report/power-report-examples.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/segmenting-revenue.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/cron.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/data/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/beacon.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/other.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/url.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/objective-c.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:30:52-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/events-or-properties.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/python/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:29:02-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/php/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:28:43-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/ruby/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:28:24-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/javascript-specific/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:25:57-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/index.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:25:33-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/common-methods.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:24:20-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/specifications.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-27T15:55:07-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/technical-limitations.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/callrail.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/convert.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/marketo.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/facebook-login.html</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/404.html</loc>
-        <lastmod>2013-08-02T10:55:34-04:00</lastmod>
+        <lastmod>2013-08-02T00:09:14-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/contact-us/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/developers/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/</loc>
-        <lastmod>2013-08-14T21:56:28-04:00</lastmod>
+        <lastmod>2013-08-27T15:58:09-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/status/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/using-kissmetrics/</loc>
-        <lastmod>2013-08-06T13:52:24-04:00</lastmod>
+        <lastmod>2013-08-06T10:40:42-07:00</lastmod>
     </url>
 </urlset>


### PR DESCRIPTION
To reduce the number of implementation problems surrounding aliases, perhaps it does not need to be so pervasively documented, considering how infrequently it's called directly. Doing that here, and leaving references only where it's extremely well documented.
