### PR TITLE
Updates to Android and iOS docs.

### DIFF
--- a/_posts/2014-02-13-android.md
+++ b/_posts/2014-02-13-android.md
@@ -48,6 +48,17 @@ properties.put("OS version", "7.1");
 KISSmetricsAPI.sharedAPI().setDistinct(properties);
 {% endhighlight %}
 
+## Initializing with Development and Production keys
+
+{% highlight java %}
+boolean isDebuggable =  ( 0 != ( getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE ) );
+if (isDebuggable) {
+	KISSmetricsAPI.sharedAPI("yourDevelopmentProductKeyHere", getApplicationContext());
+}else{
+	KISSmetricsAPI.sharedAPI("yourProductionProductKeyHere", getApplicationContext());
+}
+{% endhighlight %}
+
 # Optional Automated Tracking
 
 ## `autoRecordInstalls()`

--- a/_posts/2014-02-13-android.md
+++ b/_posts/2014-02-13-android.md
@@ -77,6 +77,7 @@ Calling this sets the following properties:
 
 If you previously used [80steve's Android library](https://github.com/80steve/KISSmetrics-4-Android), there are some functional changes from his library:
 
+* Identities, Events and Properties are URL encoded for you. If you're upgrading to this SDK, you should remove any URL encoding or URL encoded characters that may have been added as a workaround to the lack of encoding in the unoffical Android SDK.
 * The `identify` method now works the same as it does in our JavaScript library. That is, recording identities no longer aliases known identities to one another.
   * For example, if a user has been given a known identity such as "user@example.com" and a second call is made to identify: "another@example.com", the SDK no longer assumes that this a second known identity for the same user and these identities will no longer be aliased to one another automatically.
 * Now, if there are 2 or more known identities of a user, a call to `alias` these two identities must be made.

--- a/_posts/2014-02-13-android.md
+++ b/_posts/2014-02-13-android.md
@@ -15,11 +15,29 @@ We have built an official Android SDK that uses our API's [common methods][commo
 
 <https://github.com/kissmetrics/KISSmetrics-Android-SDK/releases>
 
-# Example Calls
+# Setup
+
+* Within your Application subclass or main activity's onCreate method:
 
 {% highlight java %}
 // Initialize the API
 KISSmetricsAPI.sharedAPI(<API KEY>, <Application Context>);
+{% endhighlight %}
+
+### Initializing with Development and Production keys
+
+{% highlight java %}
+boolean isDebuggable =  ( 0 != ( getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE ) );
+if (isDebuggable) {
+	KISSmetricsAPI.sharedAPI("yourDevelopmentProductKeyHere", getApplicationContext());
+}else{
+	KISSmetricsAPI.sharedAPI("yourProductionProductKeyHere", getApplicationContext());
+}
+{% endhighlight %}
+
+# Example Calls
+
+{% highlight java %}
 
 // Track Event
 KISSmetricsAPI.sharedAPI().record("Activated");
@@ -46,17 +64,6 @@ KISSmetricsAPI.sharedAPI().recordOnce("Installed App");
 HashMap<String, String> properties = new HashMap<String, String>();
 properties.put("OS version", "7.1");
 KISSmetricsAPI.sharedAPI().setDistinct(properties);
-{% endhighlight %}
-
-## Initializing with Development and Production keys
-
-{% highlight java %}
-boolean isDebuggable =  ( 0 != ( getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE ) );
-if (isDebuggable) {
-	KISSmetricsAPI.sharedAPI("yourDevelopmentProductKeyHere", getApplicationContext());
-}else{
-	KISSmetricsAPI.sharedAPI("yourProductionProductKeyHere", getApplicationContext());
-}
 {% endhighlight %}
 
 # Optional Automated Tracking

--- a/_posts/2014-02-13-ios-v2.md
+++ b/_posts/2014-02-13-ios-v2.md
@@ -30,6 +30,16 @@ This page describes version 2 of our official iOS SDK. For documention for [vers
 [KISSMetricsAPI sharedAPIWithKey:@"xxxxxxxxxxxxxxxxxxxxxxxxxxxx"];
 {% endhighlight %}
 
+### Initializing with Development and Production keys
+
+{% highlight obj-c %}
+#ifndef DEBUG
+	[KISSmetricsAPI sharedAPIWithKey:@"yourDevelopmentProductKeyHere"];
+#elif RELEASE
+	[KISSmetricsAPI sharedAPIWithKey:@"yourProductionProductKeyHere"];
+#endif 
+{% endhighlight %}
+
 # Example Calls
 
 {% highlight obj-c %}


### PR DESCRIPTION
Adds a note to the Android SDK about URL encoding.
Adds a brief setup section to match the iOS SDK docs, 
Adds example of initializing the SDKs with dev and prod. keys. 
