### PR TITLE
Updates Android SDK doc to include 'record()' on condition

### DIFF
--- a/_posts/2014-02-13-android.md
+++ b/_posts/2014-02-13-android.md
@@ -112,7 +112,11 @@ As a third party addition to our customers' apps, we should use as little of the
 
 ## Android v2 SDK specs
 
-* Size (compiled): 36KB
+* Size (compiled): 41kb
+* Memory Overhead
+  * idle: 21kb
+  * per avg. event with properties: estimated at < 500 bytes (< 200 for required params plus assumed < 300 bytes for average event with properties). During archiving of each event with properties, approximately 6kb of memory is allocated.
 * Android version support: 2.2 (Froyo) (>99% of Android devices)
+
 
 [common]: /apis/common-methods

--- a/_posts/2014-02-13-android.md
+++ b/_posts/2014-02-13-android.md
@@ -3,7 +3,7 @@ layout: post
 categories: apis
 title: "Android SDK"
 tags: []
-summary: Our official Android SDK is currently at v2.
+summary: Our official Android SDK is currently at v2.1.0.
 ---
 * Table of Contents
 {:toc}
@@ -57,8 +57,13 @@ KISSmetricsAPI.sharedAPI().set(properties);
 KISSmetricsAPI.sharedAPI().setProperty(properties);	// setProperty() is being deprecated
 
 /* New Functions as of v2 */
-// Track an event only once per user
-KISSmetricsAPI.sharedAPI().recordOnce("Installed App");
+// Track an event only once per set identity. After an identity is cleared or a new 
+// identity is set, the condition will pass once again.
+KISSmetricsAPI.sharedAPI().record("Viewed feature", KISSmetricsAPI.RecordCondition.RECORD_ONCE_PER_IDENTITY); 
+
+// Track an event only once per install
+KISSmetricsAPI.sharedAPI().record("Installed App", KISSmetricsAPI.RecordCondition.RECORD_ONCE_PER_INSTALL); 
+
 
 // Set user properties only if they have changed on the device
 HashMap<String, String> properties = new HashMap<String, String>();

--- a/_posts/2014-02-13-ios-v2.md
+++ b/_posts/2014-02-13-ios-v2.md
@@ -117,11 +117,11 @@ As a third party addition to our customers' apps, we should use as little of the
 
 ## iOS v2 SDK specs
 
-* Size (compiled): 942KB
+* Size (compiled): 942kb
 * Memory Overhead
   * idle: 330.32kb (under iOS 7)
   * per avg. event with properties: estimated at < 500 bytes (< 200 for required params plus assumed < 300 bytes for average event with properties). During archiving of each event with properties, approximately 3kb of memory is allocated and quickly released.
-  * iOS version support: iOS 5.1  (>99% of iOS devices)
+* iOS version support: iOS 5.1  (>99% of iOS devices)
 
 [common]: /apis/common-methods
 [v1]: /apis/objective-c


### PR DESCRIPTION
Updates Android SDK doc to include `record()` on condition. Removes reference to `recordOnce()`.
