### PR TITLE
Adding Core API Documentation

### DIFF
--- a/_posts/2014-09-02-core-api.md
+++ b/_posts/2014-09-02-core-api.md
@@ -65,6 +65,10 @@ be returned. Default is 20.
 
 Along with standard `pagination` information, there are also `link` elements with pre-built `URI`s for `next`, `previous`, `last`, and `first`. This allows you to reference the links in a scripted environment and for _auto pagination_. 
 
+Some links follow RFC 6570 and utilize [URI
+Templates](http://tools.ietf.org/html/rfc6570). This is denoted with the
+`templated` key. 
+
 {% highlight json %}
 {
    "links":[

--- a/_posts/2014-09-02-core-api.md
+++ b/_posts/2014-09-02-core-api.md
@@ -35,7 +35,9 @@ Content-Type: application/json
 
 #### Authentication
 
-We require **authentication** via the `Authorization` HTTP header. All requests must be made over `HTTPS`. Calls made over `HTTP` will result in an error. Authentication is required for all requests.
+We require **authentication** via the `Authorization` HTTP header. All
+requests must be made over `HTTPS`. Calls made over `HTTP` will result
+in a `301 Permanent Redirect`. Authentication is required for all requests.
 
 {% highlight http %}
 Authorization: Bearer your-token-here

--- a/_posts/2014-09-02-core-api.md
+++ b/_posts/2014-09-02-core-api.md
@@ -23,13 +23,13 @@ In order to work with our API you need to generate a **Personal Token** from wit
 
 We currently only support **JSON** (`application/json`) in our request lifecycle. You can specify this with an HTTP Header:
 
-{% highlight sh %}
+{% highlight http %}
 Accept: application/json
 {% endhighlight %}
 
 When we require a `POST` to an endpoint, such as our People Search execution, you must specify the `Content-Type`.
 
-{% highlight sh %}
+{% highlight http %}
 Content-Type: application/json
 {% endhighlight %}
 
@@ -37,7 +37,7 @@ Content-Type: application/json
 
 We require **authentication** via the `Authorization` HTTP header. All requests must be made over `HTTPS`. Calls made over `HTTP` will result in an error. Authentication is required for all requests.
 
-{% highlight sh %}
+{% highlight http %}
 Authorization: Bearer your-token-here
 {% endhighlight %}
 

--- a/_posts/2014-09-02-core-api.md
+++ b/_posts/2014-09-02-core-api.md
@@ -1,0 +1,168 @@
+---
+layout: post
+categories: apis
+title: "Core API"
+tags: []
+summary: Work with your KISSmetrics data via our core API.
+---
+* Table of Contents
+{:toc}
+* * *
+
+KISSmetrics is currently testing our Core API that allows you to
+retrieve and work with core aspects of our system. It allows you to
+query information about your **Accounts**, **Products**, **Reports**, **Events**, and
+**Properties**.
+
+## Introduction
+
+### Generate an API token
+
+In order to work with our API you need to generate **Personal Token** from within your KISSmetrics administration interface. This can be viewed from within the _Account settings_ menu option. You will see _Manage API Tokens_. From there you can **Generate a new token** and you are ready to get started.
+
+### Request Requirements
+
+#### Content Negotiation 
+
+We currently only support **JSON** (`application/json`) in our request lifecycle. You can specify this with an HTTP Header:
+
+```curl
+Accept: application/json
+```
+
+When we require a `POST` to an endpoint, such as our People Search execution, you must specify the `Content-Type`.
+
+```curl
+Content-Type: application/json
+```
+
+#### Authentication
+
+We require **authentication** via the `Authorization` HTTP header. All requests must be made over `HTTPS`. Calls made over `HTTP` will result in an error. Authentication is required for all requests.
+
+```curl
+Authorization: Bearer your-token-here
+```
+
+#### Pagination
+
+All lists of objects support pagination. Those requests will include a common pagination structure. The default `limit` is set to **20**. 
+
+```json
+{
+	"pagination": {
+		"total": 6,
+		"offset": 0,
+		"limit": 20
+	}
+}
+
+```
+
+##### Available Arguments
+
+* `limit` (optional) Use this to set the number of items to be returned.
+* `offset` (optional) Use this to specify the offset from within the collection of items.
+
+Along with standard `pagination` information, there are also `link` elements with pre-built `URI`s for `next`, `previous`, `last`, and `first`. This allows you to reference the links in a scripted environment and for _auto pagination_. 
+
+```json
+[
+	{
+		"templated": false,
+		"href": "https://api.kissmetrics.com/core/products?limit=1&offset=0",
+	    "rel": "first",
+	    "name": "First"
+	  },
+	  {
+	    "templated": false,
+	    "href": "https://api.kissmetrics.com/core/products?limit=1&offset=5",
+	    "rel": "last",
+	    "name": "Last"
+	  },
+	  {
+	    "templated": false,
+	    "href": "https://api.kissmetrics.com/core/products?limit=1&offset=2",
+	    "rel": "next",
+	    "name": "Next"
+	  },
+	  {
+	    "templated": false,
+	    "href": "https://api.kissmetrics.com/core/products?limit=1&offset=0",
+    	"rel": "prev",
+    	"name": "Previous"
+  	}
+]
+```
+
+## API Reference
+
+All requests in the examples assume proper `Authorization` and `Accept` headers. All examples utilize `curl`, but could be executed with any HTTP client of your choosing.
+
+### Root Directory
+
+The root directory returns a list of all available `link`s within the API.
+
+#### Request
+
+```curl
+curl 'https://api.kissmetrics.com/core'
+```
+
+#### Response
+
+```json
+{
+  "links": [
+    {
+      "templated": false,
+      "href": "https://api.kissmetrics.com/core",
+      "rel": "self",
+      "name": "Directory"
+    }
+  ],
+  "data": {
+    "links": [
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core",
+        "rel": "self",
+        "name": "Directory"
+      },
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/accounts",
+        "rel": "accounts",
+        "name": "Accounts"
+      },
+    ],
+    "description": "API access for KISSmetrics",
+    "name": "KISSmetrics API"
+  }
+}
+    
+```
+
+### Accounts
+
+The accounts endpoint returns a list of accounts you are authorized to access.
+
+#### Request
+
+```curl
+curl 'https://api.kissmetrics.com/core/accounts'
+```
+
+#### Response
+
+
+### Products
+
+### Reports
+
+### Events
+
+### Properties
+
+[people-search]: /tools/people-search
+[feedback]: mailto:feedback@kissmetrics.com

--- a/_posts/2014-09-02-core-api.md
+++ b/_posts/2014-09-02-core-api.md
@@ -5,9 +5,6 @@ title: "Core API"
 tags: []
 summary: Work with your KISSmetrics data via our core API.
 ---
-* Table of Contents
-{:toc}
-* * *
 
 KISSmetrics is currently testing our Core API that allows you to
 retrieve and work with core aspects of our system. It allows you to
@@ -18,7 +15,7 @@ query information about your **Accounts**, **Products**, **Reports**, **Events**
 
 ### Generate an API token
 
-In order to work with our API you need to generate **Personal Token** from within your KISSmetrics administration interface. This can be viewed from within the _Account settings_ menu option. You will see _Manage API Tokens_. From there you can **Generate a new token** and you are ready to get started.
+In order to work with our API you need to generate a **Personal Token** from within your KISSmetrics administration interface. This can be viewed from within the _Account settings_ menu option. You will see _Manage API Tokens_. From there you can **Generate a new token** and you are ready to get started.
 
 ### Request Requirements
 
@@ -26,74 +23,78 @@ In order to work with our API you need to generate **Personal Token** from withi
 
 We currently only support **JSON** (`application/json`) in our request lifecycle. You can specify this with an HTTP Header:
 
-```curl
+{% highlight sh %}
 Accept: application/json
-```
+{% endhighlight %}
 
 When we require a `POST` to an endpoint, such as our People Search execution, you must specify the `Content-Type`.
 
-```curl
+{% highlight sh %}
 Content-Type: application/json
-```
+{% endhighlight %}
 
 #### Authentication
 
 We require **authentication** via the `Authorization` HTTP header. All requests must be made over `HTTPS`. Calls made over `HTTP` will result in an error. Authentication is required for all requests.
 
-```curl
+{% highlight sh %}
 Authorization: Bearer your-token-here
-```
+{% endhighlight %}
 
 #### Pagination
 
 All lists of objects support pagination. Those requests will include a common pagination structure. The default `limit` is set to **20**. 
 
-```json
+{% highlight json %}
 {
-	"pagination": {
-		"total": 6,
-		"offset": 0,
-		"limit": 20
-	}
+   "pagination":{
+      "total":6,
+      "offset":0,
+      "limit":20
+   }
 }
-
-```
+{% endhighlight %}
 
 ##### Available Arguments
 
-* `limit` (optional) Use this to set the number of items to be returned.
-* `offset` (optional) Use this to specify the offset from within the collection of items.
+* `limit` (**optional, integer**) Use this to set the number of items to
+be returned. Default is 20.
+* `offset` (**optional, integer**) Use this to specify the offset from within the collection of items.
+
+#### Link Envelopes
 
 Along with standard `pagination` information, there are also `link` elements with pre-built `URI`s for `next`, `previous`, `last`, and `first`. This allows you to reference the links in a scripted environment and for _auto pagination_. 
 
-```json
-[
-	{
-		"templated": false,
-		"href": "https://api.kissmetrics.com/core/products?limit=1&offset=0",
-	    "rel": "first",
-	    "name": "First"
-	  },
-	  {
-	    "templated": false,
-	    "href": "https://api.kissmetrics.com/core/products?limit=1&offset=5",
-	    "rel": "last",
-	    "name": "Last"
-	  },
-	  {
-	    "templated": false,
-	    "href": "https://api.kissmetrics.com/core/products?limit=1&offset=2",
-	    "rel": "next",
-	    "name": "Next"
-	  },
-	  {
-	    "templated": false,
-	    "href": "https://api.kissmetrics.com/core/products?limit=1&offset=0",
-    	"rel": "prev",
-    	"name": "Previous"
-  	}
-]
-```
+{% highlight json %}
+{
+   "links":[
+      {
+         "templated":false,
+         "href":"https://api.kissmetrics.com/core/products?limit=1&amp;offset=0",
+         "rel":"first",
+         "name":"First"
+      },
+      {
+         "templated":false,
+         "href":"https://api.kissmetrics.com/core/products?limit=1&amp;offset=5",
+         "rel":"last",
+         "name":"Last"
+      },
+      {
+         "templated":false,
+         "href":"https://api.kissmetrics.com/core/products?limit=1&amp;offset=2",
+         "rel":"next",
+         "name":"Next"
+      },
+      {
+         "templated":false,
+         "href":"https://api.kissmetrics.com/core/products?limit=1&amp;offset=0",
+         "rel":"prev",
+         "name":"Previous"
+      }
+   ]
+}
+{% endhighlight %}
 
 ## API Reference
 
@@ -105,13 +106,13 @@ The root directory returns a list of all available `link`s within the API.
 
 #### Request
 
-```curl
+{% highlight sh %}
 curl 'https://api.kissmetrics.com/core'
-```
+{% endhighlight %}
 
 #### Response
 
-```json
+{% highlight json %}
 {
   "links": [
     {
@@ -140,29 +141,516 @@ curl 'https://api.kissmetrics.com/core'
     "name": "KISSmetrics API"
   }
 }
+{% endhighlight %}
     
-```
 
-### Accounts
+### All Accounts
 
-The accounts endpoint returns a list of accounts you are authorized to access.
+The accounts endpoint returns a list of accounts you are authorized to access. 
 
 #### Request
 
-```curl
+{% highlight sh %}
 curl 'https://api.kissmetrics.com/core/accounts'
-```
+{% endhighlight %}
 
 #### Response
 
+{% highlight json %}
+[
+  {
+    "links": [
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/accounts/51cc9c30-0edf-0131-ead3-12313b0d181e",
+        "rel": "self",
+        "name": "Self"
+      },
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/accounts/51cc9c30-0edf-0131-ead3-12313b0d181e/products",
+        "rel": "products",
+        "name": "Products"
+      }
+    ],
+    "contact": {
+      "phone": null,
+      "country": null,
+      "name": null
+    },
+    "updated_at": "2014-09-02T19:46:43Z",
+    "created_at": "2013-10-04T04:56:57Z",
+    "status": "active",
+    "name": "My SaaS Account",
+    "id": "51cc9c30-0edf-0131-ead3-12313b0d181e"
+  }
+]
 
-### Products
+{% endhighlight %}
 
-### Reports
+### Account Details
 
-### Events
+The account endpoint returns the body of the account you are authorized
+to access. You can retrieve this `URI` via several means:
 
-### Properties
+* The `links` from within an _All Accounts_ list response.
+* The **URI Template** from within the `links` inside of the _Root
+Directory_.
 
-[people-search]: /tools/people-search
+#### Link Envelopes
+
+* `self` Save a link to the Account to reference later
+* `products` Link to retrieve all _Products_ scoped to the _Account_
+
+#### Model
+
+* `id` (**UUID**) The identifier of the Account
+* `name` (**string**) The name of the Account
+* `status` (**enum, `active` or `canceled`**) The status of the Account
+* `created_at` (**datetime, ISO8601**) The date the Account was created
+* `updated_at` (**datetime, ISO8601**) The date the Account was updated
+* `contact` (**json**) The details of the person of contact for the Account
+
+#### Request
+
+{% highlight sh %}
+curl 'https://api.kissmetrics.com/core/accounts/51cc9c30-0edf-0131-ead3-12313b0d181e'
+{% endhighlight %}
+
+#### Response
+
+{% highlight json %}
+{
+  "links": [
+    {
+      "templated": false,
+      "href": "https://api.kissmetrics.com/core/accounts/51cc9c30-0edf-0131-ead3-12313b0d181e",
+      "rel": "self",
+      "name": "Self"
+    },
+    {
+      "templated": false,
+      "href": "https://api.kissmetrics.com/core/accounts/51cc9c30-0edf-0131-ead3-12313b0d181e/products",
+      "rel": "products",
+      "name": "Products"
+    }
+  ],
+  "contact": {
+    "phone": null,
+    "country": null,
+    "name": null
+  },
+  "updated_at": "2014-09-02T19:46:43Z",
+  "created_at": "2013-10-04T04:56:57Z",
+  "status": "active",
+  "name": "My Saas Account",
+  "id": "51cc9c30-0edf-0131-ead3-12313b0d181e"
+}
+
+{% endhighlight %}
+
+### All Products
+
+The products endpoint returns a collection of all products you have
+access to. If you are a member of multiple _Accounts_, then you will see
+all products across those accounts.
+
+#### Request
+
+{% highlight sh %}
+curl 'https://api.kissmetrics.com/core/products'
+{% endhighlight %}
+
+#### Response
+
+{% highlight json %}
+[
+  {
+    "links": [
+      {
+        "templated": false,
+        "href": "https://apikissmetrics.com/core/products/e7063aa0-0edf-0131-ead3-12313b0d181e",
+        "rel": "self",
+        "name": "Self"
+      },
+      {
+        "templated": false,
+        "href": "https://apikissmetrics.com/core/accounts/51cc9c30-0edf-0131-ead3-12313b0d181e",
+        "rel": "account",
+        "name": "Account"
+      },
+      {
+        "templated": false,
+        "href": "https://apikissmetrics.com/core/products/e7063aa0-0edf-0131-ead3-12313b0d181e/reports",
+        "rel": "reports",
+        "name": "Product Reports"
+      },
+      {
+        "templated": false,
+        "href": "https://apikissmetrics.com/core/products/e7063aa0-0edf-0131-ead3-12313b0d181e/events",
+        "rel": "events",
+        "name": "Product Events"
+      },
+      {
+        "templated": false,
+        "href": "https://apikissmetrics.com/core/products/e7063aa0-0edf-0131-ead3-12313b0d181e/properties",
+        "rel": "properties",
+        "name": "Product Properties"
+      }
+    ],
+    "id": "e7063aa0-0edf-0131-ead3-12313b0d181e",
+    "account_id": "51cc9c30-0edf-0131-ead3-12313b0d181e",
+    "name": "My SaaS Product",
+    "url": "http://mysaasproduct.com",
+    "status": "active",
+    "environment": "",
+    "timezone": "US/Pacific",
+    "created_at": "2013-10-04T05:01:07+00:00"
+  }
+]
+
+{% endhighlight %}
+
+### Product Details
+
+The product endpoint returns the body of the product you are authorized
+to access. You can retrieve this `URI` via several means:
+
+* The `links` from within an _All Products_ list response.
+* The **URI Template** from within the `links` inside of the _Root
+Directory_.
+
+#### Model
+
+* `id` (**UUID**) The identifier of the Product
+* `account_id` (**UUID**) The identifier of the parent Account
+* `name` (**string**) The name of the Product
+* `url` (**string**) The URL of the Product
+* `environment` (**string**) This is typically one of _production_,
+_staging_, or _development_.
+* `status` (**enum, `active`, `canceled`**) The status of the Product
+* `timezone` (**string**) The timezone of the Product
+* `created_at` (**datetime, ISO8601**) The date the Product was created
+
+#### Request
+
+{% highlight sh %}
+curl
+'https://api.kissmetrics.com/core/products/e7063aa0-0edf-0131-ead3-12313b0d181e'
+{% endhighlight %}
+
+#### Response
+
+{% highlight json %}
+{
+  "links": [],
+  "id": "e7063aa0-0edf-0131-ead3-12313b0d181e",
+  "account_id": "51cc9c30-0edf-0131-ead3-12313b0d181e",
+  "name": "My Saas Product",
+  "url": "http://mysaasproduct.com",
+  "status": "active",
+  "environment": "",
+  "timezone": "US/Pacific",
+  "created_at": "2013-10-04T05:01:07+00:00"
+}
+
+{% endhighlight %}
+
+### All Reports
+
+The reports endpoint returns a list of reports you are authorized to
+access. This includes all _Reports_ across all _Products_.
+
+#### Request
+
+{% highlight sh %}
+curl 'https://api.kissmetrics.com/core/reports'
+{% endhighlight %}
+
+#### Response
+
+{% highlight json %}
+[
+  {
+    "links": [
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/reports/64361c30-4a48-0131-0cbb-22000a9f1c0f",
+        "rel": "self",
+        "name": "Self"
+      },
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/query/reports/64361c30-4a48-0131-0cbb-22000a9f1c0f/run",
+        "rel": "run",
+        "name": "Run Report"
+      },
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/products/6c921840-0edf-0131-ead4-12313b0d181e",
+        "rel": "product",
+        "name": "Product"
+      },
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/accounts/51cc9c30-0edf-0131-ead3-12313b0d181e",
+        "rel": "account",
+        "name": "Account"
+      }
+    ],
+    "created_at": "2013-12-18T19:27:43+00:00",
+    "name": "My People Search",
+    "report_type": "people_search_v2",
+    "account_id": "51cc9c30-0edf-0131-ead3-12313b0d181e",
+    "product_id": "6c921840-0edf-0131-ead4-12313b0d181e",
+    "id": "64361c30-4a48-0131-0cbb-22000a9f1c0f"
+  }
+]
+
+{% endhighlight %}
+
+### Report Details
+
+The report endpoint returns the body of the report you are authorized to
+access. You can retrieve this `URI` via several means:
+
+* The `links` from within an _All Reports_ list response.
+* The **URI Template** from within the `links` inside of the `Root
+Directory`.
+
+#### Model
+
+* `id` (**UUID**) The identifier of the Account
+* `account_id` (**UUID**) The identifier of the parent Account
+* `product_id` (**UUID**) The identifier of the parent Product
+* `name` (**string**) The name of the Report
+* `report_type` (**string**) The type of the Report. **Note that
+`people_search_v2` are the only reports that may be run via the API**.
+* `created_at` (**datetime, ISO8601**) The date the Report was created
+
+#### Request
+
+{% highlight sh %}
+curl
+'https://api.kissmetrics.com/core/reports/64361c30-4a48-0131-0cbb-22000a9f1c0f'
+{% endhighlight %}
+
+
+#### Response
+
+{% highlight json %}
+{
+  "links": [],
+  "created_at": "2013-12-18T19:27:43+00:00",
+  "name": "My People Search",
+  "report_type": "people_search_v2",
+  "account_id": "51cc9c30-0edf-0131-ead3-12313b0d181e",
+  "product_id": "6c921840-0edf-0131-ead4-12313b0d181e",
+  "id": "64361c30-4a48-0131-0cbb-22000a9f1c0f"
+}
+
+{% endhighlight %}
+
+### All Events
+
+The events endpoint returns a list of events from your event libraries.
+This includes all _Events_ across all _Products_.
+
+#### Request
+
+{% highlight sh %}
+curl 'https://api.kissmetrics.com/core/events'
+{% endhighlight %}
+
+#### Response
+
+{% highlight json %}
+[
+  {
+    "links": [
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/events/d71bf5f0-3de7-0131-aa07-1231392acb4b",
+        "rel": "self",
+        "name": "Self"
+      },
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/products/6c921840-0edf-0131-ead4-12313b0d181e",
+        "rel": "product",
+        "name": "Product"
+      }
+    ],
+    "last_sent_at": "2014-08-29T15:41:08+00:00",
+    "first_sent_at": "2013-12-03T01:26:21+00:00",
+    "last_used_at": "2014-08-29T14:58:30+00:00",
+    "id": "d71bf5f0-3de7-0131-aa07-1231392acb4b",
+    "product_id": "6c921840-0edf-0131-ead4-12313b0d181e",
+    "name": "search engine hit",
+    "display_name": "Search engine hit",
+    "description": null,
+    "is_visible": true,
+    "total": 8,
+    "first_used_at": "2013-12-03T01:02:05+00:00"
+  }
+]
+
+{% endhighlight %}
+
+### Event Details
+
+The event endpoint returns the body of the event you are authorized to
+access. You can retrieve this `URI` via several means:
+
+* The `links` from within an _All Events_ list response.
+* The `links` from within an _All Products_ list response via the
+`events` link relationship. This will return events scoped to that
+product.
+* The **URI Template** from within the `links` inside of the _Root
+Directory_.
+
+#### Model
+
+* `id` (**UUID**) The identifier of the _Event_
+* `product_id` (**UUID**) The identifier of the parent _Product_
+* `name` (**string**) The name of the Event
+* `display_name` (**string**) The display name of the Event
+* `description` (**text**) The description of the Event
+* `is_visible` (**boolean**) The visibility of the Event in the Event
+Library
+* `total` (**integer**) The total times this Event has been tracked
+* `first_used_at` (**datetime, ISO8601**) The date this Event was first used
+* `last_used_at` (**datetime, ISO8601**) The date this Event was last used
+* `first_sent_at` (**datetime, ISO8601**) The date this Event was first
+sent
+* `last_sent_at` (**datetime, ISO8601**) The date this Event was last
+sent
+
+#### Request
+
+{% highlight sh %}
+curl
+'https://api.kissmetrics.com/core/events/d71bf5f0-3de7-0131-aa07-1231392acb4b'
+{% endhighlight %}
+
+#### Response
+
+{% highlight json %}
+{
+  "links": [],
+  "last_sent_at": "2014-08-29T15:41:08+00:00",
+  "first_sent_at": "2013-12-03T01:26:21+00:00",
+  "last_used_at": "2014-08-29T14:58:30+00:00",
+  "id": "d71bf5f0-3de7-0131-aa07-1231392acb4b",
+  "product_id": "6c921840-0edf-0131-ead4-12313b0d181e",
+  "name": "search engine hit",
+  "display_name": "Search engine hit",
+  "description": null,
+  "is_visible": true,
+  "total": 8,
+  "first_used_at": "2013-12-03T01:02:05+00:00"
+}
+
+{% endhighlight %}
+
+### All Properties
+
+The properties endpoint returns a list of properties defined. This
+includes all _Property_ records across all _Products_.
+
+#### Request
+
+{% highlight sh %}
+curl 'https://api.kissmetrics.com/core/properties'
+{% endhighlight %}
+
+#### Response
+
+{% highlight json %}
+[
+  {
+    "links": [
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/properties/6234e85e-2941-11e4-a20e-12313932e372",
+        "rel": "self",
+        "name": "Self"
+      },
+      {
+        "templated": false,
+        "href": "https://api.kissmetrics.com/core/products/6c921840-0edf-0131-ead4-12313b0d181e",
+        "rel": "product",
+        "name": "Product"
+      }
+    ],
+    "last_sent_at": "2014-08-29T22:43:17+00:00",
+    "first_sent_at": "2013-10-04T05:58:54+00:00",
+    "last_used_at": "2014-08-29T21:50:32+00:00",
+    "id": "6234e85e-2941-11e4-a20e-12313932e372",
+    "product_id": "6c921840-0edf-0131-ead4-12313b0d181e",
+    "type": null,
+    "name": "referrer",
+    "display_name": "Referrer",
+    "description": null,
+    "is_visible": true,
+    "first_used_at": "2013-10-04T05:00:09+00:00"
+  }
+]
+
+{% endhighlight %}
+
+### Property Details
+
+The property endpoint returns the body of the property you are
+authorized to access. You can retrieve this `URI` via several means:
+
+* The `links` from within an _All Properties_ list response.
+* The `links` from within an _All Products_ list response via the
+`events` link relationship. This will return properties scoped to that
+product.
+* The **URI Template** from within the `links` inside of the _Root
+Directory_.
+
+#### Model
+
+* `id` (**UUID**) The identifier of the _Property_
+* `product_id` (**UUID**) The identifier of the parent Product
+* `name` (**string**) The name of the Property
+* `display_name` (**string**) The display name of the Property
+* `description` (**text**) The description of the Property
+* `is_visible` (**boolean**) The visibility of the Property
+* `type` (**enum, `automatic`, `text`, `number`**) The type of the Property
+* `first_used_at` (**datetime, ISO8601**) The date this Property was first used
+* `last_used_at` (**datetime, ISO8601**) The date this Property was last used
+* `first_sent_at` (**datetime, ISO8601**) The date this Property was first
+sent
+* `last_sent_at` (**datetime, ISO8601**) The date this Property was last
+sent
+
+#### Request
+
+{% highlight sh %}
+curl 'https://api.kissmetrics.com/core/properties/6234e85e-2941-11e4-a20e-12313932e372'
+{% endhighlight %}
+
+#### Response
+
+{% highlight json %}
+{
+  "links": [],
+  "last_sent_at": "2014-08-29T22:43:17+00:00",
+  "first_sent_at": "2013-10-04T05:58:54+00:00",
+  "last_used_at": "2014-08-29T21:50:32+00:00",
+  "id": "6234e85e-2941-11e4-a20e-12313932e372",
+  "product_id": "6c921840-0edf-0131-ead4-12313b0d181e",
+  "type": null,
+  "name": "referrer",
+  "display_name": "Referrer",
+  "description": null,
+  "is_visible": true,
+  "first_used_at": "2013-10-04T05:00:09+00:00"
+}
+
+{% endhighlight %}
+
 [feedback]: mailto:feedback@kissmetrics.com

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,832 +2,832 @@
 <urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/overview.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/people-events-properties.html</loc>
-        <lastmod>2014-07-24T09:56:59-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/ways-to-send-us-data.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/testing-km/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/testing-km/using-dev-tools.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/understanding-identities.html</loc>
-        <lastmod>2014-07-23T12:49:05-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/faq.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/security.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/introduction.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/webinar-getting-started.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/installation/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/html-files.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/installation/wordpress-tutorial.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/events-intro.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/event-library-tutorial/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tutorial/event-library-tutorial/events-and-properties-tutorial.html
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tutorial/event-library-tutorial/events-url-tutorial.html
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tutorial/event-library-tutorial/events-clicks-tutorial.html
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tutorial/event-library-tutorial/events-form-tutorial.html
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/metrics-intro.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/how-to-build-reports.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/account-billing.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/advanced-properties</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/browser-detection.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/call-tracking-metrics.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/campaign-tracking.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/chargify.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/cohort-report/cohort-report-options.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/create-site.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/daily-metrics-email.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/data-discrepancies/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/data/data-export-setup.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/deleting-data.html</loc>
-        <lastmod>2014-06-27T15:00:21-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/detecting-duplicates.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/dynamic-elements.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/ecommerce-essentials.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/events-clicks.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/events-form.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/events-url/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/form-abandonment.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/funnels/index.html</loc>
-        <lastmod>2014-08-04T14:15:44-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/funnels-vs-metrics.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/ruby/heroku.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/hosting-js-yourself.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/how-is-kissmetrics-different.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/importing-data</loc>
-        <lastmod>2014-07-22T12:02:00-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/integration</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/internet-explorer.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/ip-filtering.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/javascript-identities.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/javascript-settings.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/data-discrepancies/km-ga.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/live.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/local-development</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/magento-km.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/mailchimp.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/metrics/metric-calculations.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/metrics/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/mobile-sites-apps.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/multiple-people-same-browser</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/csv-import/one-time-upload.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/optimizely.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/payplans.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/person-details.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/person-or-account.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/power-report/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/apis/javascript/javascript-specific/protected-form-fields.html
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/python/python-gae.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/qualaroo.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/recurly.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/csv-import/recurring-import.html</loc>
-        <lastmod>2014-07-09T11:15:19-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/power-report/relative-to.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/reports-exportable.html</loc>
-        <lastmod>2014-08-04T14:15:44-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/revenue-report.html</loc>
-        <lastmod>2014-08-04T15:29:57-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/ruby/ruby-on-rails.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/saas-essentials.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tools/funnels/segment-funnels-two-properties.html
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/self-referrer.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/server-side</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/site-settings.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/social-events.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/time-on-site.html</loc>
-        <lastmod>2014-07-15T10:29:03-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/time-zones.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/too-many-event-names.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/top-vs-bottom.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/tracking-email.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/tracking-offline-events.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/tracking-refunds.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/tracking-video.html</loc>
-        <lastmod>2014-07-23T09:56:05-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/traffic-sources.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/troubleshooting-properties.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/user-privacy.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/using-paypal.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/utm-variables.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/advanced/virality</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/vwo.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/using-km-js/weighted-variants</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/what-can-km-do-for-me.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/what-should-i-measure.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/what-youll-learn.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/using-km-js/whole-page</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/events-url/wildcards.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/woocommerce.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/wordpress.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/wufoo-forms.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/cohort-report/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/overview/five-awesome-things.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/google-tag-manager.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/km-live.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/people-search.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/ultracart.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/tracking-multiple-domains.html</loc>
-        <lastmod>2014-06-26T16:31:09-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/mysql/arg-out-of-range.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/delete-site.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/main-saas-funnel.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/paid-ads.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/roi-email-marketing.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/roi-of-seo.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/roi-social-media.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/social-media.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/team-permissions.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
-    </url>
-    <url>
-        <loc>http://support.kissmetrics.com/integrations/salesforce.html</loc>
-        <lastmod>2014-07-23T12:49:05-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/finding-power-users.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/marketing-power-report.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/change-password.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/compare-features-power-report.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/roi-campaigns.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/stop-events.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/csv-import/index.html</loc>
-        <lastmod>2014-07-09T11:04:33-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/mysql/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/using-km-js/index.html</loc>
-        <lastmod>2014-07-22T15:12:58-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/styleguide.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/troubleshooting-identities.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/update-frequency.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/what-does-none-mean.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/troubleshooting/common-cohort-report-questions.html
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/saas-revenue-essentials</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/help-scout.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/power-report/power-report-examples.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/segmenting-revenue.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/cron.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/data/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/beacon.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/other.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/url.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/objective-c.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/events-or-properties.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/python/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/php/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/ruby/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/javascript-specific/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/javascript/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/common-methods.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/specifications.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/technical-limitations.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/callrail.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/convert.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/marketo.html</loc>
-        <lastmod>2014-07-07T13:58:17-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/facebook-login.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/move-business-faster.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/what-are-events.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/install-our-js.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/recording-your-first-js-event.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/creating-your-first-report.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/what-are-properties.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/what-are-people.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/identifying-people.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/additional-data-sources.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/data-out.html</loc>
-        <lastmod>2014-07-14T12:51:05-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/push-notifications.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/tapstream.html</loc>
-        <lastmod>2014-07-01T09:47:57-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/android.html</loc>
-        <lastmod>2014-07-23T16:23:15-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/ios-v2.html</loc>
-        <lastmod>2014-07-23T16:23:15-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/a-b-test-report/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/tools/a-b-test-report/certainty-of-improvement.html
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/a-b-test-report/no-clear-winner.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/json-import/index.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/integrations/json-import/one-time-json-upload.html
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/integrations/json-import/recurring-json-import.html
         </loc>
-        <lastmod>2014-07-09T12:59:06-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>
             http://support.kissmetrics.com/best-practices/ecommerce-essentials/js-and-server-side-examples
         </loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/ecommerce-essentials/js-examples</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/saas-essentials/js-examples</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/appcues.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/shopify.html</loc>
-        <lastmod>2014-07-17T13:28:51-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/event-library/events-url-regex.html</loc>
-        <lastmod>2014-07-10T15:51:20-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
+    </url>
+    <url>
+        <loc>http://support.kissmetrics.com/apis/core-api.html</loc>
+        <lastmod>2014-09-02T15:40:17-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/404.html</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:55-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/a-b-testing/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/best-practices/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/developers/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/getting-started/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/how-tos/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/</loc>
-        <lastmod>2014-08-04T15:29:57-07:00</lastmod>
+        <lastmod>2014-09-02T15:40:17-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/learn/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/misc/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tools/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/troubleshooting/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/tutorial/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/use-cases/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/using-kissmetrics/</loc>
-        <lastmod>2014-06-26T15:14:08-07:00</lastmod>
+        <lastmod>2014-09-02T15:32:56-04:00</lastmod>
     </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -764,7 +764,7 @@
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/core-api.html</loc>
-        <lastmod>2014-09-02T17:49:06-04:00</lastmod>
+        <lastmod>2014-09-03T09:26:41-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/404.html</loc>
@@ -796,7 +796,7 @@
     </url>
     <url>
         <loc>http://support.kissmetrics.com/</loc>
-        <lastmod>2014-09-02T17:49:06-04:00</lastmod>
+        <lastmod>2014-09-03T09:26:41-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/</loc>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -764,7 +764,7 @@
     </url>
     <url>
         <loc>http://support.kissmetrics.com/apis/core-api.html</loc>
-        <lastmod>2014-09-02T15:40:17-04:00</lastmod>
+        <lastmod>2014-09-02T17:49:06-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/404.html</loc>
@@ -796,7 +796,7 @@
     </url>
     <url>
         <loc>http://support.kissmetrics.com/</loc>
-        <lastmod>2014-09-02T15:40:17-04:00</lastmod>
+        <lastmod>2014-09-02T17:49:06-04:00</lastmod>
     </url>
     <url>
         <loc>http://support.kissmetrics.com/integrations/</loc>


### PR DESCRIPTION
This adds documentation for the upcoming core API endpoints for _accounts_, _products_, _reports_, _events_, and _properties_.
