### PR TITLE
Updated People Search docs

### DIFF
--- a/_posts/2012-11-04-people-search.md
+++ b/_posts/2012-11-04-people-search.md
@@ -14,17 +14,17 @@ Our Person Search helps you find people who share something in common, whether t
 
 You can save this search to use later or export this list of people to your email campaigns, to re-engage or analyze their behaviors to find common actions that drive engagement or conversions.
 
-# Creating Groups
+# Using conditions to create a People Search
 
-Before you can search for customers, you’ll need to describe the type of people you’re looking for. We call these similar people Groups.
+Before you can search for customers, you’ll need to describe the type of people you’re looking for with conditions.
 
-KISSmetrics lets you create a Group based on:
+KISSmetrics lets you create a People Search based on:
 
 * An **event** people have or have not done, within the report's time frame.
 * A **property** people have or don’t have, within the report's time frame.
 * An **identity** (usually an email address)
 
-## How do I create Groups in KISSmetrics?
+## Step by step on how to create a People Search
 
 ![Person Search 02][ss02]
 
@@ -46,15 +46,23 @@ After you pick an event, you can pick a frequency. The available choices are:
 * at most
 * exactly
 
+After you pick a property, you can pick logic on how to limit the condition what property you are looking for. The available choices are:
+
+* contains (property value must contain what is submitted i.e. SPRING would work for SPRING2014 and SPRINGCOUPON)
+* equals (property value must match exactly what is submitted i.e SPRING would look for exactly SPRING)
+* empty (property value exists, but is empty or nulll; this is used to check for any data sets that may be missing data or that should contain something)
+* any (all users who have the property, including empty values)
+
+
 We default to at least 1 time for events, but you can change it easily by putting in whatever number you like.
 
 ![Person Search 06][ss06]
 
 You can add more conditions to create a more specific group of people. Add as many conditions as you like to create specific customer segments.
 
-### Nesting conditions for advanced Groups
+### Nesting conditions for advanced searches
 
-If you have very specific customer segments or criteria you want to meet, KISSmetrics People Search lets you nest conditions to build complex customer groups.
+If you have very specific customer segments or criteria you want to meet, KISSmetrics People Search lets you nest conditions to build complex searches.
 
 ![Person Search 07][ss07]
 
@@ -68,9 +76,9 @@ When you use multiple nests, you can create advanced Groups. This particular Gro
 * and have NOT Logged in but Viewed the Get Started Page AND Played the Getting Started Video
 * and are on the Large plan
 
-# Making Your People Search Results Awesome
+# Add additional data to your People Search
 
-You can get more than just a list of people with KISSmetrics People Search. Customize your search results to see even more data about your Group.
+You can get more than just a list of people with KISSmetrics People Search. Customize your search results to see even more data by adding additional data columns (up to 3 additional columns.)
 
 Example: Of all the people who `Signed Up`...
 
@@ -80,11 +88,11 @@ Example: Of all the people who `Signed Up`...
 
 ![Person Search 09][ss09]
 
-## Adding search result columns to your People Search
+## Adding additional data columns to your People Search
 
 ![Person Search 10][ss10]
 
-By default, KISSmetrics will list the people that satisfy your Group conditions. But you can make your search results much more useful by adding in event activity or property information.
+By default, KISSmetrics will list the people that satisfy your search conditions. But you can make your search results much more useful by adding in event activity or property information.
 
 ![Person Search 11][ss11]
 
@@ -117,7 +125,7 @@ To save a People Search, click the "Save this search" button.
 
 ![Person Search 15][ss15]
 
-You can access Saved People Searches from the Reports tab.
+You can access Saved People Searches from the Reports section of KISSmetrics.
 
 ![Person Search 16][ss16]
 


### PR DESCRIPTION
Updated copy and text to reflect new property choices in People Search:
- contains (property value must contain what is submitted i.e. SPRING
  would work for SPRING2014 and SPRINGCOUPON)
- equals (property value must match exactly what is submitted i.e
  SPRING would look for exactly SPRING)
- empty (property value exists, but is empty or nulll; this is used to
  check for any data sets that may be missing data or that should contain
  something)
- any (all users who have the property, including empty values)
