### PR TITLE
Modified syntax for events and added properties

### DIFF
--- a/_posts/2012-10-19-tracking-video.md
+++ b/_posts/2012-10-19-tracking-video.md
@@ -12,9 +12,15 @@ Below are examples of using the [YouTube](#youtube), [Vimeo](#vimeo), and [Wisti
 
 # Events Recorded
 
-* Played Video - {Name of the Video}
-* Paused Video - {Name of the Video}
-* Finished Video - {Name of the Video}
+* Played Video
+* Paused Video
+* Finished Video
+
+# Properties Recorded
+
+* Played Video Name
+* Paused Video Name
+* Finished Video Name
 
 # Vimeo
 
@@ -47,11 +53,11 @@ var videoName = "Sample Video";
 // Add listeners after the player is ready.
 player.addEvent('ready', function() {
   player.addEvent('play', function(){
-    _kmq.push(['record', 'Played Video - ' + videoName]); });
+    _kmq.push(['record', 'Played Video', {'Played Video Name':videoName}]);
   player.addEvent('pause', function(){
-    _kmq.push(['record', 'Paused Video - ' + videoName]); });
+    _kmq.push(['record', 'Paused Video', {'Paused Video Name':videoName}]);
   player.addEvent('finish', function(){
-    _kmq.push(['record', 'Finished Video - ' + videoName]); });
+    _kmq.push(['record', 'Finished Video', {'Finished Video Name':videoName}]);
 });
 </script>
 {% endhighlight %}
@@ -71,13 +77,13 @@ Now below this, let's add our tracking calls.
 function loadKMTrackableVideo (wistia_object, videoName) {
   // Add tracking to 'play', 'pause', and 'end' events.
   wistia_object.bind("play", function() {
-    _kmq.push(['record', 'Played video - ' + videoName]);
+    _kmq.push(['record', 'Played Video', {'Played Video Name':videoName}]);
   });
   wistia_object.bind("pause", function() {
-    _kmq.push(['record', 'Paused video - ' + videoName]);
+    _kmq.push(['record', 'Paused Video', {'Paused Video Name':videoName}]);
   });
   wistia_object.bind("end", function() {
-    _kmq.push(['record', 'Finished video - ' + videoName]);
+    _kmq.push(['record', 'Finished Video', {'Finished Video Name':videoName}]);
   });
 }
 
@@ -141,13 +147,13 @@ var _kmq = _kmq || [];
 function onPlayerStateChange(event) {
   switch(event.data) {
     case YT.PlayerState.PLAYING:
-      _kmq.push(['record', 'Played Video - ' + player.getVideoData().title]);
+      _kmq.push(['record', 'Played Video', {'Played Video Name':videoName}]);
       break;
     case YT.PlayerState.PAUSED:
-      _kmq.push(['record', 'Paused Video - ' + player.getVideoData().title]);
+      _kmq.push(['record', 'Paused Video', {'Paused Video Name':videoName}]);
       break;
     case YT.PlayerState.ENDED:
-      _kmq.push(['record', 'Finished Video - ' + player.getVideoData().title]);
+      _kmq.push(['record', 'Finished Video', {'Finished Video Name':videoName}]);
       break;
     default:
       return;


### PR DESCRIPTION
The old format encouraged users to dynamically generate event names which has led to event count blowups. This new format allows for a better aggregate within the reporting tools.
