### PR TITLE
Demonstrate how to require the PHP library without Composer

### DIFF
--- a/_posts/2013-04-18-php.md
+++ b/_posts/2013-04-18-php.md
@@ -33,6 +33,7 @@ Before calling any of the common methods, you must initialize with a valid API k
 
 {% highlight php %}
 <?
+  require( 'KISSMetrics/KM.php' );
   $km = new KISSmetrics\Client($KM_KEY, KISSmetrics\Transport\Sockets::initDefault()); // Initialize
 ?>
 {% endhighlight %}


### PR DESCRIPTION
Addresses follow-up of https://github.com/kissmetrics/km-support/issues/117.
