### PR TITLE
Remove U+2028 line break character

### DIFF
--- a/_posts/2012-10-19-ip-filtering.md
+++ b/_posts/2012-10-19-ip-filtering.md
@@ -13,7 +13,7 @@ summary: Here are options for filtering certain people from generating Kissmetri
 For most customers, internal traffic is such a small volume compared to their overall traffic that it does not have an impact on their conversion rates.  Customers who do heavy internal QA testing usually prefer to set up a separate Kissmetrics site for their staging/development environment so that their testing activity is recorded under a separate Kissmetrics API key.
 
 However, if there is a specific reason why your internal traffic needs to be ignored, we'd like to hear it.  We're always interested in hearing customer feedback that may tip us off to use cases we hadn't anticipated.
- 
+
 ### Notes on the Alternatives
 
 * There is no way to exclude certain data after the fact.


### PR DESCRIPTION
The unicode character was screwing up the way that Markdown generated the HTML and therefore didn't render correctly on the site.

Affected page: http://support.kissmetrics.com/troubleshooting/ip-filtering

From this:
<img width="535" alt="ip_blocking_and_filtering_-_kissmetrics_documentation 2" src="https://cloud.githubusercontent.com/assets/7666402/10857600/f4dd2dee-7f46-11e5-9689-880d6b0a0dd2.png">

To this:
<img width="540" alt="ip_blocking_and_filtering_-_kissmetrics_documentation" src="https://cloud.githubusercontent.com/assets/7666402/10857604/f9f35e34-7f46-11e5-9d70-acc794789bf4.png">
